### PR TITLE
fix: ObjectWrapper using ClientSet to avoid reading cache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nacos-group/nacos-controller/pkg/nacos"
 	"github.com/nacos-group/nacos-controller/pkg/nacos/auth"
 	"github.com/nacos-group/nacos-controller/pkg/nacos/client/impl"
+	"k8s.io/client-go/kubernetes"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -94,7 +95,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controller.NewDynamicConfigurationReconciler(mgr.GetClient(), mgr.GetScheme(), nacos.SyncConfigOptions{
+	clientSet := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
+
+	if err = controller.NewDynamicConfigurationReconciler(mgr.GetClient(), clientSet, nacos.SyncConfigOptions{
 		ConfigClient: impl.NewDefaultNacosConfigClient(auth.NewDefaultNacosAuthProvider(mgr.GetClient())),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DynamicConfiguration")

--- a/pkg/controller/dynamicconfiguration_controller.go
+++ b/pkg/controller/dynamicconfiguration_controller.go
@@ -24,11 +24,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	runtimehandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,15 +48,13 @@ const (
 // DynamicConfigurationReconciler reconciles a DynamicConfiguration object
 type DynamicConfigurationReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
 	controller *nacos.SyncConfigurationController
 }
 
-func NewDynamicConfigurationReconciler(c client.Client, s *runtime.Scheme, opt nacos.SyncConfigOptions) *DynamicConfigurationReconciler {
+func NewDynamicConfigurationReconciler(c client.Client, cs *kubernetes.Clientset, opt nacos.SyncConfigOptions) *DynamicConfigurationReconciler {
 	return &DynamicConfigurationReconciler{
 		Client:     c,
-		Scheme:     s,
-		controller: nacos.NewSyncConfigurationController(c, opt),
+		controller: nacos.NewSyncConfigurationController(c, cs, opt),
 	}
 }
 

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nacos-group/nacos-controller/pkg/nacos"
 	"github.com/nacos-group/nacos-controller/pkg/nacos/auth"
 	"github.com/nacos-group/nacos-controller/pkg/nacos/client/impl"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	"os"
 	"path/filepath"
@@ -84,7 +85,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewDynamicConfigurationReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), nacos.SyncConfigOptions{
+	clientSet := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
+
+	err = NewDynamicConfigurationReconciler(k8sManager.GetClient(), clientSet, nacos.SyncConfigOptions{
 		ConfigClient: impl.NewDefaultNacosConfigClient(auth.NewDefaultNacosAuthProvider(k8sManager.GetClient())),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"github.com/nacos-group/nacos-controller/pkg/nacos"
+	"github.com/nacos-group/nacos-controller/pkg/nacos/auth"
+	"github.com/nacos-group/nacos-controller/pkg/nacos/client/impl"
 	"k8s.io/utils/pointer"
 	"os"
 	"path/filepath"
@@ -82,7 +84,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewDynamicConfigurationReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), nacos.SyncConfigOptions{}).SetupWithManager(k8sManager)
+	err = NewDynamicConfigurationReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), nacos.SyncConfigOptions{
+		ConfigClient: impl.NewDefaultNacosConfigClient(auth.NewDefaultNacosAuthProvider(k8sManager.GetClient())),
+	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
设计Controller时考虑到需要监听ConfigMap资源会造成内存消耗偏高，因此监听的是ConfigMapMetadata变更。

ObjectWrapper中使用的是读缓存的Client，有可能导致读取的ConfigMap是旧数据，导致配置不同步到Naocs-Server中。

改用Clientset，直接从ApiServer获取ConfigMap资源