### PR TITLE
feat: Output Nacos SDK connection failure logs to console

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"log"
 	"os"
 
 	"github.com/nacos-group/nacos-controller/pkg/nacos"
@@ -55,6 +56,7 @@ func init() {
 }
 
 func main() {
+	log.SetOutput(os.Stdout)
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string


### PR DESCRIPTION
Redirects the standard Go logger output to os.Stdout in main.go. This allows Nacos SDK logs, particularly those related to connection failures, to be visible in the console output of the nacos-controller, aiding in debugging and monitoring connection issues with the Nacos server.