### PR TITLE
fix: respect objectRefs in partial sync mode

### DIFF
--- a/pkg/nacos/util.go
+++ b/pkg/nacos/util.go
@@ -52,7 +52,7 @@ func DynamicConfigurationMatch(object client.Object, dc *nacosiov1.DynamicConfig
 			return true
 		}
 	}
-	return true
+	return false
 }
 
 func GetAllKeys(object client.Object) []string {


### PR DESCRIPTION
Fix an issue in DynamicConfigurationMatch where unmatched resources incorrectly return true, causing all ConfigMaps and Secrets in the namespace to be synchronized when sync scope is set to partial.

修复 DynamicConfigurationMatch 中的问题，当资源不匹配时错误地返回 true，导致在同步范围设置为partial时，命名空间中的所有 ConfigMaps 和 Secrets 都被同步。